### PR TITLE
feat: 자기소개서 개별 항목 관련 기능 구현

### DIFF
--- a/api/routers/cover_letter.py
+++ b/api/routers/cover_letter.py
@@ -1,10 +1,12 @@
 # app/api/routers/cover_letter.py
+from http import HTTPStatus
 from typing import Optional
+from uuid import UUID
 from fastapi import APIRouter, Depends, Query, HTTPException, status
 from deps.auth import get_current_user_id
 from schemas.cover_letter import (
     CoverLetterCreate, CoverLetterUpdate,
-    CoverLetterResponse, CoverLetterListResponse,
+    CoverLetterResponse, CoverLetterListResponse, QnACreate, QnAUpdate
 )
 from services.cover_letter import CoverLetterService
 
@@ -49,3 +51,29 @@ async def delete_cover_letter(
     user_id: str = Depends(get_current_user_id),
 ):
     return await svc.delete(user_id, cl_id)
+
+# === 자기소개서 항목 관련 로직===
+@router.post("/{cl_id}/qnas", response_model=CoverLetterResponse, status_code=HTTPStatus.CREATED, summary="자기소개서 항목 생성")
+async def create_qna(
+    cl_id: str,
+    body: QnACreate,
+    user_id: str = Depends(get_current_user_id)
+):
+    return await svc.create_qna(user_id, cl_id, body)
+
+@router.patch("/{cl_id}/qnas/{qna_id}", response_model=CoverLetterResponse, summary="문항 수정 (유저가 question/answer 수정)")
+async def update_qna(
+    cl_id: str,
+    qna_id: UUID,
+    body: QnAUpdate,
+    user_id: str = Depends(get_current_user_id)
+):
+    return await svc.update_qna(user_id, cl_id, qna_id, body)
+
+@router.delete("/{cl_id}/qnas/{qna_id}", response_model=CoverLetterResponse, summary="문항 삭제")
+async def delete_qna(
+    cl_id: str,
+    qna_id: UUID,
+    user_id: str = Depends(get_current_user_id),
+):
+    return await svc.delete_qna(user_id, cl_id, qna_id)

--- a/models/cover_letter_document.py
+++ b/models/cover_letter_document.py
@@ -2,7 +2,15 @@
 from datetime import datetime, timezone
 from typing import Optional, Literal, List
 from beanie import Document, Indexed
-from pydantic import Field
+from pydantic import Field, BaseModel
+from uuid import UUID
+
+class QnA(BaseModel):
+    id: UUID
+    question: str
+    answer: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
 
 class CoverLetterDocument(Document):
     """
@@ -12,9 +20,9 @@ class CoverLetterDocument(Document):
     """
     user_id: Indexed(str) = Field(...)  # UserDocument.id (str)
     title: str
-    content: str
     type: Literal["profile", "job_posting"]
     job_posting_id: Optional[str] = None
+    qnas: List[QnA] = Field(default_factory=list)
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -25,3 +33,4 @@ class CoverLetterDocument(Document):
             [("user_id", 1), ("updated_at", -1)],
             [("user_id", 1), ("type", 1), ("updated_at", -1)],
         ]
+

--- a/repositories/cover_letter_repository.py
+++ b/repositories/cover_letter_repository.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from typing import Optional, Dict, Any
 from repositories.mongo_repositories.cover_letter_mongodb_repository import CoverLetterMongoDBRepository
+from uuid import UUID
 
 class CoverLetterRepository:
     def __init__(
@@ -29,3 +30,15 @@ class CoverLetterRepository:
 
     async def delete(self, cl_id: str) -> bool:
         return await self.mongo.delete(cl_id)
+
+    # == 자기소개서 항목 생성, 수정, 삭제 ==
+    # async def create_qna(self, cl_id: str, qna_dict: Dict[str, Any]):
+    # rag 에서 구현 후 주입 필요
+
+    # 자기소개서 개별 질문 수정
+    async def update_qna(self, cl_id: str, qna_id: UUID, fields: Dict[str, Any]):
+        return await self.mongo.update_qna(cl_id, qna_id, fields)
+
+    # 자기소개서 개별 질문 삭제
+    async def delete_qna(self, cl_id: str, qna_id: UUID):
+        return await self.mongo.delete_qna(cl_id, qna_id)

--- a/schemas/cover_letter.py
+++ b/schemas/cover_letter.py
@@ -2,18 +2,35 @@
 from datetime import datetime
 from typing import Optional, Literal, List
 from pydantic import BaseModel, Field, ConfigDict
+from uuid import UUID, uuid4
+
+class QnA(BaseModel):
+    id: UUID = Field(default_factory=uuid4, description="문항에 대한 식별자")
+    question: str = Field(..., description="자기소개서 문항")
+    answer: str = Field(..., description="문항에 맞는 답변")
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
 
 class CoverLetterCreate(BaseModel):
     """자기소개서 생성 요청"""
     title: str = Field(..., min_length=1, max_length=100, description="자기소개서 제목")
-    content: str = Field(..., min_length=1, description="자기소개서 내용 (AI로 생성된 결과를 넣어도 됨)")
     type: Literal["profile", "job_posting"] = Field(..., description="자기소개서 타입")
     job_posting_id: Optional[str] = Field(None, description="공고 기반일 경우 해당 공고 id")
+    qnas: Optional[List[QnA]] = Field(default=None, description="초기 문항 리스트")
 
 class CoverLetterUpdate(BaseModel):
-    """자기소개서 수정 요청 (부분 업데이트)"""
+    """자기소개서 상위 메타 수정 요청 (부분 업데이트), 문항 수정은 별도 엔드포인트로 진행"""
     title: Optional[str] = Field(None, min_length=1, max_length=100)
-    content: Optional[str] = Field(None, min_length=1)
+
+class QnACreate(BaseModel):
+    """자기소개서 개별 항목 생성 -> AI로 생성 진행"""
+    question: str = Field(..., min_length=1, max_length=100, description="자기소개서 문항 질문")
+    answer: Optional[str] = None
+
+class QnAUpdate(BaseModel):
+    """자기소개서 개별 항목 수정 -> 유저가 수정"""
+    question: Optional[str]
+    answer: Optional[str] = None
 
 class CoverLetterResponse(BaseModel):
     """클라이언트 응답 모델"""
@@ -22,9 +39,9 @@ class CoverLetterResponse(BaseModel):
     id: str
     user_id: str
     title: str
-    content: str
     type: Literal["profile", "job_posting"]
     job_posting_id: Optional[str] = None
+    qnas: List[QnA]
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
## ✨ 작업 내용
- 자기소개서 개별 항목 생성, 수정, 삭제 기능 구현
  - 모델, 스키마, 레포지토리, 서비스, 라우터 구현
  - 자기소개서 생성 관련 로직은 RAG로 추가 구현 필요(엔드포인트, 서비스, 레포지토리의 메서드만 추가해놓은 상태)

---

## 📝 적용 범위
- `models/cover-letter.py`
- `schemas/cover-letter.py`
- `services/cover-letter.py`
- `repositories/cover_letter_repository.py`
- `repositories/mongo_repositories/cover_letter_mongodb_repository.py`
- `api/routers/cover-letter.py`

---

## 📌 참고 사항
- 관련 이슈(#22)